### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Dupmon/BAO/DupmonBatch.php
+++ b/CRM/Dupmon/BAO/DupmonBatch.php
@@ -29,7 +29,7 @@ class CRM_Dupmon_BAO_DupmonBatch extends CRM_Dupmon_DAO_DupmonBatch {
       $params['group_id'] = $groupId;
     }
 
-    CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
+    CRM_Utils_Hook::pre($hook, $entityName, $params['id'] ?? NULL, $params);
     $instance = new $className();
     $instance->copyValues($params);
     $instance->save();

--- a/CRM/Dupmon/BAO/DupmonRuleMonitor.php
+++ b/CRM/Dupmon/BAO/DupmonRuleMonitor.php
@@ -18,7 +18,7 @@ class CRM_Dupmon_BAO_DupmonRuleMonitor extends CRM_Dupmon_DAO_DupmonRuleMonitor 
     $entityName = 'DupmonRuleMonitor';
     $hook = empty($params['id']) ? 'create' : 'edit';
 
-    CRM_Utils_Hook::pre($hook, $entityName, CRM_Utils_Array::value('id', $params), $params);
+    CRM_Utils_Hook::pre($hook, $entityName, $params['id'] ?? NULL, $params);
     $instance = new $className();
     $instance->copyValues($params);
     $instance->save();

--- a/CRM/Dupmon/Form/Settings.php
+++ b/CRM/Dupmon/Form/Settings.php
@@ -219,7 +219,7 @@ class CRM_Dupmon_Form_Settings extends CRM_Core_Form {
   public function setDefaultValues() {
     $result = civicrm_api3('setting', 'get', array('return' => array_keys($this->_settings)));
     $domainID = CRM_Core_Config::domainID();
-    $ret = CRM_Utils_Array::value($domainID, $result['values']);
+    $ret = $result['values'][$domainID] ?? NULL;
 
     foreach ($this->_ruleMonitors as $ruleMonitor) {
       $ret['enable-monitor-rule-group-' . $ruleMonitor['rule_group_id']] = (bool) $ruleMonitor['is_active'];


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.