### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/api/v3/DedupeMonitor/Scan.php
+++ b/api/v3/DedupeMonitor/Scan.php
@@ -23,7 +23,7 @@ function _civicrm_api3_dedupe_monitor_Scan_spec(&$spec) {
  *
  * @see civicrm_api3_create_success
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_dedupe_monitor_Scan($params) {
   // Populate batches

--- a/api/v3/DupmonBatch.php
+++ b/api/v3/DupmonBatch.php
@@ -26,7 +26,7 @@ function _civicrm_api3_dupmon_batch_create_spec(&$spec) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_dupmon_batch_create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'DupmonBatch');
@@ -40,7 +40,7 @@ function civicrm_api3_dupmon_batch_create($params) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_dupmon_batch_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -54,7 +54,7 @@ function civicrm_api3_dupmon_batch_delete($params) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_dupmon_batch_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params, TRUE, 'DupmonBatch');

--- a/api/v3/DupmonRuleInfo.php
+++ b/api/v3/DupmonRuleInfo.php
@@ -21,7 +21,7 @@ function _civicrm_api3_dupmon_rule_info_create_spec(&$spec) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_dupmon_rule_info_create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'DupmonRuleInfo');
@@ -35,7 +35,7 @@ function civicrm_api3_dupmon_rule_info_create($params) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_dupmon_rule_info_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -49,7 +49,7 @@ function civicrm_api3_dupmon_rule_info_delete($params) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_dupmon_rule_info_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params, TRUE, 'DupmonRuleInfo');

--- a/api/v3/DupmonRuleMonitor.php
+++ b/api/v3/DupmonRuleMonitor.php
@@ -21,7 +21,7 @@ function _civicrm_api3_dupmon_rule_monitor_create_spec(&$spec) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_dupmon_rule_monitor_create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, 'DupmonRuleMonitor');
@@ -35,7 +35,7 @@ function civicrm_api3_dupmon_rule_monitor_create($params) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_dupmon_rule_monitor_delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -49,7 +49,7 @@ function civicrm_api3_dupmon_rule_monitor_delete($params) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_dupmon_rule_monitor_get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params, TRUE, 'DupmonRuleMonitor');


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.